### PR TITLE
Add Airtable Script

### DIFF
--- a/airtable-script
+++ b/airtable-script
@@ -1,0 +1,11 @@
+---
+collection: "Content management"
+platform: "Airtable"
+type: "Extension"
+developer: "Create Today"
+developer_url: "https://createtoday.io"
+price: "Free"
+url: "https://createtoday.io/posts/compress-airtable-attachments-with-tinypng"
+---
+
+Blog post with copy and paste script to bulk compress Airtable attachments with TinyPNG. No middleman needed, easy to use, customizable, and free!

--- a/airtable-script.md
+++ b/airtable-script.md
@@ -8,4 +8,5 @@ price: "Free"
 url: "https://createtoday.io/posts/compress-airtable-attachments-with-tinypng"
 ---
 
-Blog post with copy and paste script to bulk compress Airtable attachments with TinyPNG. No middleman needed, easy to use, customizable, and free!
+Blog post with copy and paste script to bulk compress Airtable attachments with
+TinyPNG. No middleman needed, easy to use, customizable, and free!


### PR DESCRIPTION
This is a blog post that contains a copy and paste script that connects Airtable and TinyPNG. After seeing the only option was a paid extension, I developed a custom script to make Airtable work directly with TinyPNG (that is without a middleman and cost free).